### PR TITLE
Remove CODEOWNERS file punya bang nobel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @NobelNizam @kaderisasiceohmsd
+


### PR DESCRIPTION
Mohon maaf bang, kami tidak sengaja menarik folder yang ada di  branch main ke branch Markov yang menyebabkan codeowner branch Markov ada 2, yaitu bang nobel dan hazel, ketika kami ingin melakukan push dari branch sendiri ke branch kelompok, kami harus di merge pull/acc oleh bang nobel terlebih dahulu, karena otoritas codeowner bang nobel diatas milik hazel, sekali lagi kami mohon maaf bang